### PR TITLE
Fix server flags in docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 8087:8087
     expose:
       - 8087
-    command: --master-host master --master-port 8086 --host 0.0.0.0 --port 8087
+    command: --master-host master --master-port 8086 --http-host 0.0.0.0 --http-port 8087
   master:
     image: zhenghaoz/gorse-master
     restart: always


### PR DESCRIPTION
Fixes unknown flags error that prevents the server from starting. Logs:
```server_1  | Error: unknown flag: --host
server_1  | Usage:
server_1  |   gorse-server [flags]
server_1  |
server_1  | Flags:
server_1  |   -h, --help                 help for gorse-server
server_1  |       --http-host string     host of RESTful API (default "127.0.0.1")
server_1  |       --http-port int        port of RESTful API (default 8087)
server_1  |       --master-host string   host of master node (default "127.0.0.1")
server_1  |       --master-port int      port of master node (default 8086)
server_1  |   -v, --version              gorse version
server_1  |
server_1  | {"level":"fatal","ts":1619948463.674005,"caller":"gorse-server/main.go:55","msg":"failed to execute","error":"unknown flag: --host","stacktrace":"main.main\n\t/go/src/github.com/zhenghaoz/gorse/cmd/gorse-server/main.go:55\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204"}```
