### PR TITLE
fix sql 1064 error: AS new ON DUPLICATE KEY UPDATE value = new.value, `comment` = new.comment

### DIFF
--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -197,8 +197,8 @@ func (d *SQLDatabase) InsertMeasurement(measurement Measurement) error {
 	var err error
 	switch d.driver {
 	case MySQL:
-		_, err = d.client.Exec("INSERT INTO measurements(name, time_stamp, value, `comment`) VALUES (?, ?, ?, ?) AS new "+
-			"ON DUPLICATE KEY UPDATE value = new.value, `comment` = new.comment",
+		_, err = d.client.Exec("INSERT INTO measurements(name, time_stamp, value, `comment`) VALUES (?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE value = VALUES(value), `comment` = VALUES(`comment`)",
 			measurement.Name, measurement.Timestamp, measurement.Value, measurement.Comment)
 	case Postgres:
 		_, err = d.client.Exec("INSERT INTO measurements(name, time_stamp, value, comment) VALUES ($1, $2, $3, $4)  "+
@@ -297,8 +297,8 @@ func (d *SQLDatabase) BatchInsertItem(items []Item) error {
 		}
 		switch d.driver {
 		case MySQL:
-			builder.WriteString(" AS new ON DUPLICATE KEY " +
-				"UPDATE time_stamp = new.time_stamp, labels = new.labels, `comment` = new.comment")
+			builder.WriteString(" ON DUPLICATE KEY " +
+				"UPDATE time_stamp = VALUES(time_stamp), labels = VALUES(labels), `comment` = VALUES(`comment`)")
 		case Postgres:
 			builder.WriteString(" ON CONFLICT (item_id) " +
 				"DO UPDATE SET time_stamp = EXCLUDED.time_stamp, labels = EXCLUDED.labels, comment = EXCLUDED.comment")
@@ -867,7 +867,7 @@ func (d *SQLDatabase) BatchInsertFeedback(feedback []Feedback, insertUser, inser
 		}
 		switch d.driver {
 		case MySQL:
-			builder.WriteString(" AS new ON DUPLICATE KEY UPDATE time_stamp = new.time_stamp, `comment` = new.`comment`")
+			builder.WriteString(" ON DUPLICATE KEY UPDATE time_stamp = VALUES(time_stamp), `comment` = VALUES(`comment`)")
 		case Postgres:
 			builder.WriteString(" ON CONFLICT (feedback_type, user_id, item_id) DO UPDATE SET time_stamp = EXCLUDED.time_stamp, comment = EXCLUDED.comment")
 		}


### PR DESCRIPTION
sql syntax:
https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html

`Beginning with MySQL 8.0.19, it is possible to use an alias for the row, with, optionally, one or more of its columns to be inserted, following the VALUES or SET clause, and preceded by the AS keyword. Using the row alias new, the statement shown previously using VALUES() to access the new column values can be written in the form shown here:`

fix mysql sql error:


```
Analyze click-through rate | Failed | 2021/09/09 07:37 |   | Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AS new ON DUPLICATE KEY UPDATE value = new.value, `comment` = new.comment' at line 1
-- | -- | -- | -- | --

```

